### PR TITLE
Meta updates (dates, author details, document filename)

### DIFF
--- a/draft-kazuho-httpbis-http3-on-streams.md
+++ b/draft-kazuho-httpbis-http3-on-streams.md
@@ -18,7 +18,7 @@ author:
     email: lucas@lucaspardue.com
 -
     fullname: Jana Iyengar
-    organization: Fastly
+    organization: Netflix
     email: jri.ietf@gmail.com
 
 normative:
@@ -42,7 +42,7 @@ This document specifies how to use HTTP/3 over QMux.
 
 # Introduction
 
-As of 2023, HTTP/2 {{RFC9113}} remains the most widely used version of
+As of 2026, HTTP/2 {{RFC9113}} remains the most widely used version of
 HTTP across the Internet, although the adoption rate of HTTP/3
 {{RFC9114}} is increasing rapidly.
 

--- a/draft-kazuho-httpbis-http3-over-qmux.md
+++ b/draft-kazuho-httpbis-http3-over-qmux.md
@@ -1,6 +1,6 @@
 ---
 title: "HTTP/3 over QMux"
-docname: draft-kazuho-httpbis-http3-on-streams-latest
+docname: draft-kazuho-httpbis-http3-over-qmux-latest
 category: std
 wg: httpbis
 ipr: trust200902


### PR DESCRIPTION
- meta updates for 2026
- rename draft to draft-kazuho-httpbis-http3-over-qmux

This would switch the I-D to be draft-kazuho-httpbis-http3-over-qmux(-00). We'd want to take care when publishing to ensure its linked to the previous name. A one-time manual submission is usually the most cast-iron way to ensure it happens during the transition.